### PR TITLE
Fix search query generation when model generates thinking tags

### DIFF
--- a/src/ollama_deep_researcher/prompts.py
+++ b/src/ollama_deep_researcher/prompts.py
@@ -79,6 +79,14 @@ Format your response as a JSON object with these exact keys:
 - follow_up_query: Write a specific question to address this gap
 </FORMAT>
 
+<EXAMPLE>
+Example output:
+{{
+    "knowledge_gap": "The summary lacks information about performance metrics and benchmarks",
+    "follow_up_query": "What are typical performance benchmarks and metrics used to evaluate [specific technology]?"
+}}
+</EXAMPLE>
+
 <Task>
 Reflect carefully on the Summary to identify knowledge gaps and produce a follow-up query. Then, produce your output following this JSON format:
 {{


### PR DESCRIPTION
I ran into an issue using LMStudio with the qwq-32b, deepseek-r1-distill-qwen-7b and deepseek-r1-llama-8b models. In the generate_query and reflect_on_summary steps, the models return text with thinking tags before the actual JSON. With the DeepSeek models, I also saw that DeepSeek recommended using <EXAMPLE></EXAMPLE> to enclose an example of the desired output. This pull request updates the reflect_on_summary prompt with example tags and moves the stripping of think tags to earlier both reflect_on_summary and generate_query so the JSON part of the response can be parsed.